### PR TITLE
fix mixins count display

### DIFF
--- a/frontend/src/Transaction/Transaction.js
+++ b/frontend/src/Transaction/Transaction.js
@@ -63,7 +63,7 @@ const Transaction = () => {
                                 <div>
                                     {transactionInfo.inputs && [...Array(transactionInfo.inputs.length).keys()].map(i => (
                                         <div key={(i)}>
-                                            <RingSignature txHash={transactionInfo.tx_hash} keyImage={transactionInfo.inputs[i].key_image} mixin={transactionInfo.inputs[i].mixins.length + 1} />
+                                            <RingSignature txHash={transactionInfo.tx_hash} keyImage={transactionInfo.inputs[i].key_image} mixin={transactionInfo.inputs[i].mixins.length} />
                                         </div>
                                     ))}
                                 </div>


### PR DESCRIPTION
Merge conflict: if you plan to merge #8, this PR should be closed

If I understand it correctly, this elem displays the number of mixins. Therefore it is not needed to increase the length of the array by one, because the length of the array represents the number of mixins.