### PR TITLE
Use cached tx_hash instead of downloading each one by one

### DIFF
--- a/frontend/src/Transaction/TransactionLink/TransactionLink.js
+++ b/frontend/src/Transaction/TransactionLink/TransactionLink.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
-import { BctApi } from '../../agent';
-
 import styles from './TransactionLink.module.css';
 
 const TransactionLink = ({ blockInfo, txHash }) => {

--- a/frontend/src/Transaction/TransactionLink/TransactionLink.js
+++ b/frontend/src/Transaction/TransactionLink/TransactionLink.js
@@ -1,28 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import styles from './TransactionLink.module.css';
 
 const TransactionLink = ({ blockInfo, txHash }) => {
-    const [transactionHash, setTransactionHash] = useState(txHash);
-    const [isLoading, setIsLoading] = useState(false);
-
-    useEffect(() => {
-        const fetchTransactionHash = async () => {
-            setIsLoading(true)
-
-            setTransactionHash(blockInfo.tx_hash)
-            setIsLoading(false)  
-        }
-
-        if (!transactionHash) {
-            fetchTransactionHash();
-        }
-    })
-
-    return !isLoading ? (
-        <Link className={styles.TransactionLink} to={`/transaction/${transactionHash}`} />
-    ) : null;
+    return <Link className={styles.TransactionLink} to={`/transaction/${txHash ?? blockInfo.tx_hash}`} />
 }
 
 export default TransactionLink;

--- a/frontend/src/Transaction/TransactionLink/TransactionLink.js
+++ b/frontend/src/Transaction/TransactionLink/TransactionLink.js
@@ -13,10 +13,7 @@ const TransactionLink = ({ blockInfo, txHash }) => {
         const fetchTransactionHash = async () => {
             setIsLoading(true)
 
-            const transactionResult = await BctApi.getTransaction(blockInfo.block_no, blockInfo.public_key);
-            const { transactionId } = await transactionResult.json()
-    
-            setTransactionHash(transactionId)
+            setTransactionHash(blockInfo.tx_hash)
             setIsLoading(false)  
         }
 


### PR DESCRIPTION
Merge conflict: if you plan to merge #8, this PR should be closed

The tx_hash of each mixin is already downloaded in the first request. This update makes the loading of RingCT inputs instant on the page, making the whole transactions site load much faster.
![image](https://github.com/DiedB/Monero-Blockchain-Explorer/assets/10603822/67d9aa7c-7d03-40d7-acae-1073b46f8df4)
